### PR TITLE
Fix missing frontend dependencies in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     command: npm run dev
     volumes:
       - ./frontend:/app
+      - /app/node_modules
     environment:
       - NODE_ENV=development
     networks:


### PR DESCRIPTION
## Summary
- preserve frontend node dependencies by adding a node_modules volume

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_686e84211940832db64f186ec5cbf0ec