### PR TITLE
Align endpoints with Ads API

### DIFF
--- a/backend/ads/services.py
+++ b/backend/ads/services.py
@@ -39,6 +39,27 @@ class YelpService:
         return resp.json()
 
     @classmethod
+    def edit_program(cls, program_id, payload):
+        url = f'{cls.PARTNER_BASE}/v1/reseller/program/{program_id}/edit'
+        resp = requests.post(url, json=payload, auth=cls.auth_partner)
+        resp.raise_for_status()
+        return resp.json()
+
+    @classmethod
+    def terminate_program(cls, program_id):
+        url = f'{cls.PARTNER_BASE}/v1/reseller/program/{program_id}/end'
+        resp = requests.post(url, auth=cls.auth_partner)
+        resp.raise_for_status()
+        return resp.json()
+
+    @classmethod
+    def get_job_status(cls, job_id):
+        url = f'{cls.PARTNER_BASE}/v1/reseller/status/{job_id}'
+        resp = requests.get(url, auth=cls.auth_partner)
+        resp.raise_for_status()
+        return resp.json()
+
+    @classmethod
     def request_report(cls, period, payload):
         url = f'{cls.FUSION_BASE}/v3/reporting/businesses/{period}'
         resp = requests.post(url, json=payload, headers=cls.headers_fusion)

--- a/backend/ads/urls.py
+++ b/backend/ads/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
 from .views import (
     CreateProgramView,
+    EditProgramView,
+    TerminateProgramView,
+    JobStatusView,
     BusinessMatchView,
     SyncSpecialtiesView,
     RequestReportView,
@@ -8,9 +11,19 @@ from .views import (
 )
 
 urlpatterns = [
+    # Legacy endpoints
     path('programs/', CreateProgramView.as_view()),
     path('businesses/matches/', BusinessMatchView.as_view()),
     path('businesses/sync/', SyncSpecialtiesView.as_view()),
     path('reports/<str:period>/', RequestReportView.as_view()),
     path('reports/<str:period>/<str:report_id>/', FetchReportView.as_view()),
+
+    # Endpoints aligned with Yelp Ads API
+    path('reseller/program/create', CreateProgramView.as_view()),
+    path('reseller/program/<str:program_id>/edit', EditProgramView.as_view()),
+    path('reseller/program/<str:program_id>/end', TerminateProgramView.as_view()),
+    path('reseller/status/<str:job_id>', JobStatusView.as_view()),
+
+    path('reporting/businesses/<str:period>/', RequestReportView.as_view()),
+    path('reporting/businesses/<str:period>/<str:report_id>/', FetchReportView.as_view()),
 ]

--- a/backend/ads/views.py
+++ b/backend/ads/views.py
@@ -18,6 +18,21 @@ class SyncSpecialtiesView(APIView):
         data = YelpService.sync_specialties(request.data)
         return Response(data)
 
+class EditProgramView(APIView):
+    def post(self, request, program_id):
+        data = YelpService.edit_program(program_id, request.data)
+        return Response(data)
+
+class TerminateProgramView(APIView):
+    def post(self, request, program_id):
+        data = YelpService.terminate_program(program_id)
+        return Response(data)
+
+class JobStatusView(APIView):
+    def get(self, request, job_id):
+        data = YelpService.get_job_status(job_id)
+        return Response(data)
+
 class RequestReportView(APIView):
     def post(self, request, period):
         data = YelpService.request_report(period, request.data)


### PR DESCRIPTION
## Summary
- add API service helpers for editing, terminating, and checking job status
- expose new backend views and URL routes matching Yelp Ads API
- keep legacy URLs but add `reseller/*` and `reporting/businesses/*` routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_6870fcbe1ffc832db095c7b7b4636b13