### PR TITLE
Fix API proxy for local dev

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
 NODE_ENV=development
+VITE_BACKEND_URL=http://backend:8000

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,12 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/api": {
+        target: process.env.VITE_BACKEND_URL || "http://backend:8000",
+        changeOrigin: true,
+      },
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- add Vite proxy so API requests go to the backend
- document `VITE_BACKEND_URL` in env example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6871038f4820832dae30d5e2bbb46818