### PR TITLE
Fix missing trailing slash handling for reporting endpoint

### DIFF
--- a/backend/ads/urls.py
+++ b/backend/ads/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import path, re_path
 from .views import (
     CreateProgramView,
     EditProgramView,
@@ -24,6 +24,6 @@ urlpatterns = [
     path('reseller/program/<str:program_id>/end', TerminateProgramView.as_view()),
     path('reseller/status/<str:job_id>', JobStatusView.as_view()),
 
-    path('reporting/businesses/<str:period>/', RequestReportView.as_view()),
-    path('reporting/businesses/<str:period>/<str:report_id>/', FetchReportView.as_view()),
+    re_path(r'^reporting/businesses/(?P<period>[^/]+)/?$', RequestReportView.as_view()),
+    re_path(r'^reporting/businesses/(?P<period>[^/]+)/(?P<report_id>[^/]+)/?$', FetchReportView.as_view()),
 ]


### PR DESCRIPTION
## Summary
- allow optional trailing slashes in reporting/businesses URLs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_6871070a0688832d94defd752c3393c3