### PR TITLE
Add basic auth login support

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -73,6 +73,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.TokenAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import BusinessSearch from './components/BusinessSearch';
 import Dashboard from './components/Dashboard';
 import JobStatusMonitor from './components/JobStatusMonitor';
 import CategoryManager from './components/CategoryManager';
+import Login from './pages/Login';
 import NotFound from "./pages/NotFound";
 
 const App = () => (
@@ -22,6 +23,7 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
+          <Route path="/login" element={<Login />} />
           <Route path="/" element={<Layout />}>
             <Route index element={<Index />} />
             <Route path="create" element={<CreateProgram />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -26,6 +26,7 @@ const Layout: React.FC = () => {
     { name: 'Аналитика', href: '/dashboard', icon: BarChart3 },
     { name: 'Мониторинг задач', href: '/jobs', icon: Clock },
     { name: 'Управление категориями', href: '/categories', icon: Settings },
+    { name: 'Логин', href: '/login', icon: Home },
   ];
 
   return (

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { setCredentials } from '../store/slices/authSlice';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useNavigate } from 'react-router-dom';
+
+const Login: React.FC = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    dispatch(setCredentials({ username, password }));
+    navigate('/');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm mx-auto space-y-4 mt-10">
+      <div className="space-y-2">
+        <Label htmlFor="username">Логин</Label>
+        <Input id="username" value={username} onChange={(e) => setUsername(e.target.value)} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="password">Пароль</Label>
+        <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      </div>
+      <Button type="submit" className="w-full">Войти</Button>
+    </form>
+  );
+};
+
+export default Login;

--- a/frontend/src/store/api/yelpApi.ts
+++ b/frontend/src/store/api/yelpApi.ts
@@ -1,5 +1,6 @@
 
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '../index';
 import {
   Program,
   CreateProgramRequest,
@@ -13,9 +14,13 @@ import {
 
 const baseQuery = fetchBaseQuery({
   baseUrl: '/api', // Проксировать через бекенд
-  prepareHeaders: (headers) => {
-    // Базовая авторизация будет обрабатываться на бекенде
+  prepareHeaders: (headers, { getState }) => {
     headers.set('Content-Type', 'application/json');
+    const { auth } = (getState() as RootState);
+    if (auth.username && auth.password) {
+      const encoded = btoa(`${auth.username}:${auth.password}`);
+      headers.set('Authorization', `Basic ${encoded}`);
+    }
     return headers;
   },
 });

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -3,12 +3,14 @@ import { configureStore } from '@reduxjs/toolkit';
 import { yelpApi } from './api/yelpApi';
 import programsReducer from './slices/programsSlice';
 import reportsReducer from './slices/reportsSlice';
+import authReducer from './slices/authSlice';
 
 export const store = configureStore({
   reducer: {
     [yelpApi.reducerPath]: yelpApi.reducer,
     programs: programsReducer,
     reports: reportsReducer,
+    auth: authReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(yelpApi.middleware),

--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface AuthState {
+  username: string;
+  password: string;
+}
+
+const initialState: AuthState = {
+  username: '',
+  password: '',
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setCredentials: (state, action: PayloadAction<AuthState>) => {
+      state.username = action.payload.username;
+      state.password = action.payload.password;
+    },
+    clearCredentials: (state) => {
+      state.username = '';
+      state.password = '';
+    },
+  },
+});
+
+export const { setCredentials, clearCredentials } = authSlice.actions;
+export default authSlice.reducer;


### PR DESCRIPTION
## Summary
- add basic authentication slice and login page
- attach auth slice to redux store
- send Basic Auth header from API slice
- expose login route in layout and router
- enable BasicAuthentication in DRF settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68710ad92760832d894d4d5c948bc7cb