### PR TITLE
Implement job_id handling and persist auth credentials

### DIFF
--- a/backend/ads/models.py
+++ b/backend/ads/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 
 class Program(models.Model):
-    program_id = models.CharField(max_length=100, unique=True)
+    job_id = models.CharField(max_length=100, unique=True)
     name = models.CharField(max_length=255)
     budget = models.DecimalField(max_digits=12, decimal_places=2)
     start_date = models.DateField()
@@ -11,7 +11,7 @@ class Program(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
 class Report(models.Model):
-    report_id = models.CharField(max_length=100, unique=True)
+    job_id = models.CharField(max_length=100, unique=True)
     period = models.CharField(max_length=10)
     requested_at = models.DateTimeField(auto_now_add=True)
     data = models.JSONField()

--- a/backend/ads/services.py
+++ b/backend/ads/services.py
@@ -15,12 +15,12 @@ class YelpService:
         resp.raise_for_status()
         data = resp.json()
         Program.objects.create(
-            program_id=data['program_id'],
-            name=payload.get('name', ''),
+            job_id=data['job_id'],
+            name=payload['program_name'],
             budget=payload.get('budget', 0),
-            start_date=payload.get('start_date'),
-            end_date=payload.get('end_date'),
-            status=data.get('status', ''),
+            start_date=payload['start'],
+            end_date=payload['end'],
+            status='PENDING',
         )
         return data
 
@@ -65,7 +65,11 @@ class YelpService:
         resp = requests.post(url, json=payload, headers=cls.headers_fusion)
         resp.raise_for_status()
         data = resp.json()
-        Report.objects.create(report_id=data['report_id'], period=period, data={})
+        Report.objects.create(
+            job_id=data.get('report_id', data.get('job_id')),
+            period=period,
+            data={},
+        )
         return data
 
     @classmethod
@@ -74,7 +78,7 @@ class YelpService:
         resp = requests.get(url, headers=cls.headers_fusion)
         resp.raise_for_status()
         data = resp.json()
-        report = Report.objects.get(report_id=report_id)
+        report = Report.objects.get(job_id=report_id)
         report.data = data
         report.save()
         return data

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { setCredentials } from '../store/slices/authSlice';
 import { Button } from '@/components/ui/button';
@@ -11,6 +11,15 @@ const Login: React.FC = () => {
   const navigate = useNavigate();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('credentials');
+    if (stored) {
+      const creds = JSON.parse(stored);
+      setUsername(creds.username || '');
+      setPassword(creds.password || '');
+    }
+  }, []);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -5,6 +5,9 @@ import programsReducer from './slices/programsSlice';
 import reportsReducer from './slices/reportsSlice';
 import authReducer from './slices/authSlice';
 
+const stored = localStorage.getItem('credentials');
+const preloadedState = stored ? { auth: JSON.parse(stored) } : undefined;
+
 export const store = configureStore({
   reducer: {
     [yelpApi.reducerPath]: yelpApi.reducer,
@@ -14,6 +17,7 @@ export const store = configureStore({
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(yelpApi.middleware),
+  preloadedState,
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -5,10 +5,10 @@ interface AuthState {
   password: string;
 }
 
-const initialState: AuthState = {
-  username: '',
-  password: '',
-};
+const stored = localStorage.getItem('credentials');
+const initialState: AuthState = stored
+  ? JSON.parse(stored)
+  : { username: '', password: '' };
 
 const authSlice = createSlice({
   name: 'auth',
@@ -17,10 +17,12 @@ const authSlice = createSlice({
     setCredentials: (state, action: PayloadAction<AuthState>) => {
       state.username = action.payload.username;
       state.password = action.payload.password;
+      localStorage.setItem('credentials', JSON.stringify(action.payload));
     },
     clearCredentials: (state) => {
       state.username = '';
       state.password = '';
+      localStorage.removeItem('credentials');
     },
   },
 });


### PR DESCRIPTION
## Summary
- track program and report jobs via `job_id`
- adjust program creation and report retrieval logic
- persist login credentials in localStorage
- preload credentials when Redux store initializes
- load stored credentials on the login page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68710f5abc44832d81a60a042b000599