### PR TITLE
Auto-create Django user with Yelp credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ pip install -r requirements.txt
 user and password are both `yelpadmin`. When running via Docker Compose set
 `DATABASE_URL` to use `db` as the host instead of `localhost`.
 
+   The backend automatically creates a Django user using `YELP_API_KEY` and
+   `YELP_API_SECRET` from the environment. These values must match the login
+   and password you use on the frontend so that requests authenticated with
+   `BasicAuthentication` are accepted.
+
 3. Apply migrations
 
 ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,7 @@
 DATABASE_URL=postgres://yelpadmin:yelpadmin@db:5432/yelp
 YELP_API_KEY=your_key
 YELP_API_SECRET=your_secret
+# A Django user is automatically created with these credentials
 YELP_FUSION_TOKEN=your_token
 SECRET_KEY=change_me
 DEBUG=True

--- a/backend/ads/apps.py
+++ b/backend/ads/apps.py
@@ -1,5 +1,24 @@
 from django.apps import AppConfig
 
+
+def _ensure_default_user():
+    """Create a Django user based on Yelp API credentials if missing."""
+    from django.conf import settings
+    from django.contrib.auth import get_user_model
+
+    username = getattr(settings, "YELP_API_KEY", None)
+    password = getattr(settings, "YELP_API_SECRET", None)
+
+    if not username or not password:
+        return
+
+    User = get_user_model()
+    if not User.objects.filter(username=username).exists():
+        User.objects.create_user(username=username, password=password)
+
 class AdsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'ads'
+
+    def ready(self):
+        _ensure_default_user()


### PR DESCRIPTION
## Summary
- create a user on startup based on `YELP_API_KEY` and `YELP_API_SECRET`
- document the behaviour in `README.md`
- note the credentials in `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_687125124100832da4165f87cb8052a1