### PR TITLE
Fix bad credentials parsing

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -15,9 +15,14 @@ const Login: React.FC = () => {
   useEffect(() => {
     const stored = localStorage.getItem('credentials');
     if (stored) {
-      const creds = JSON.parse(stored);
-      setUsername(creds.username || '');
-      setPassword(creds.password || '');
+      try {
+        const creds = JSON.parse(stored);
+        setUsername(creds.username || '');
+        setPassword(creds.password || '');
+      } catch (err) {
+        console.error('Failed to parse credentials from localStorage', err);
+        localStorage.removeItem('credentials');
+      }
     }
   }, []);
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -6,7 +6,15 @@ import reportsReducer from './slices/reportsSlice';
 import authReducer from './slices/authSlice';
 
 const stored = localStorage.getItem('credentials');
-const preloadedState = stored ? { auth: JSON.parse(stored) } : undefined;
+let preloadedState: { auth: { username: string; password: string } } | undefined;
+if (stored) {
+  try {
+    preloadedState = { auth: JSON.parse(stored) };
+  } catch (err) {
+    console.error('Failed to parse credentials from localStorage', err);
+    localStorage.removeItem('credentials');
+  }
+}
 
 export const store = configureStore({
   reducer: {

--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -6,9 +6,19 @@ interface AuthState {
 }
 
 const stored = localStorage.getItem('credentials');
-const initialState: AuthState = stored
-  ? JSON.parse(stored)
-  : { username: '', password: '' };
+let parsedCreds: AuthState | null = null;
+if (stored) {
+  try {
+    parsedCreds = JSON.parse(stored);
+  } catch (err) {
+    console.error('Failed to parse credentials from localStorage', err);
+    localStorage.removeItem('credentials');
+  }
+}
+const initialState: AuthState = parsedCreds ?? {
+  username: '',
+  password: '',
+};
 
 const authSlice = createSlice({
   name: 'auth',


### PR DESCRIPTION
## Summary
- add safe parsing for credentials in the frontend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_687129ec4dac832dbd15ccb3f186f41b