### PR TITLE
Use billed metrics for daily report

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -58,8 +58,8 @@ const Dashboard: React.FC = () => {
   // Подготовка данных для графиков
   const chartData = reportData?.data || [];
   
-  const totalImpressions = chartData.reduce((sum, item) => sum + item.impressions, 0);
-  const totalClicks = chartData.reduce((sum, item) => sum + item.clicks, 0);
+  const totalImpressions = chartData.reduce((sum, item) => sum + item.billed_impressions, 0);
+  const totalClicks = chartData.reduce((sum, item) => sum + item.billed_clicks, 0);
   const totalCalls = chartData.reduce((sum, item) => sum + item.calls, 0);
   const totalCost = chartData.reduce((sum, item) => sum + item.cost, 0);
   const ctr = totalImpressions > 0 ? ((totalClicks / totalImpressions) * 100).toFixed(2) : '0';
@@ -205,8 +205,8 @@ const Dashboard: React.FC = () => {
                     <YAxis />
                     <Tooltip />
                     <Legend />
-                    <Line type="monotone" dataKey="impressions" stroke="#8884d8" name="Показы" />
-                    <Line type="monotone" dataKey="clicks" stroke="#82ca9d" name="Клики" />
+                    <Line type="monotone" dataKey="billed_impressions" stroke="#8884d8" name="Показы" />
+                    <Line type="monotone" dataKey="billed_clicks" stroke="#82ca9d" name="Клики" />
                   </LineChart>
                 </ResponsiveContainer>
               </CardContent>

--- a/frontend/src/store/api/yelpApi.ts
+++ b/frontend/src/store/api/yelpApi.ts
@@ -105,7 +105,10 @@ export const yelpApi = createApi({
           start_date,
           end_date,
           business_ids: [business_id],
-          metrics: ['impressions', 'clicks'],
+          metrics: [
+            'billed_impressions',
+            'billed_clicks',
+          ],
         },
       }),
     }),

--- a/frontend/src/types/yelp.ts
+++ b/frontend/src/types/yelp.ts
@@ -54,8 +54,8 @@ export interface BusinessMatch {
 
 export interface ReportData {
   date: string;
-  impressions: number;
-  clicks: number;
+  billed_impressions: number;
+  billed_clicks: number;
   calls: number;
   cost: number;
 }


### PR DESCRIPTION
## Summary
- switch to `billed_impressions` and `billed_clicks` metrics in RTK query
- update types and dashboard to use new metrics

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68714540cb58832d8325c2ee3f3a7852