### PR TITLE
Fix request payload keys and error handling

### DIFF
--- a/backend/ads/services.py
+++ b/backend/ads/services.py
@@ -83,7 +83,11 @@ class YelpService:
             "end":          payload.get("end")
                              or payload.get("end_date")
                              or payload.get("endDate"),
-            "business_ids": payload.get("business_ids") or payload.get("ids"),
+            "ids": [
+                b.strip()
+                for b in (payload.get("business_ids") or [payload.get("business_id")])
+                if b
+            ],
             "metrics":      payload.get("metrics"),
         }
 

--- a/backend/ads/views.py
+++ b/backend/ads/views.py
@@ -1,6 +1,7 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+import requests
 from .services import YelpService
 from .models import Program
 from .serializers import ProgramSerializer
@@ -38,8 +39,13 @@ class JobStatusView(APIView):
 
 class RequestReportView(APIView):
     def post(self, request, period):
-        data = YelpService.request_report(period, request.data)
-        return Response(data)
+        try:
+            data = YelpService.request_report(period, request.data)
+        except ValueError as ve:
+            return Response({"detail": str(ve)}, status=status.HTTP_400_BAD_REQUEST)
+        except requests.HTTPError as he:
+            return Response({"detail": he.response.text}, status=he.response.status_code)
+        return Response(data, status=status.HTTP_202_ACCEPTED)
 
 class FetchReportView(APIView):
     def get(self, request, period, report_id):


### PR DESCRIPTION
## Summary
- trim spaces and send ids list when requesting reports
- return clear errors from RequestReportView

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68714cc98a48832db70805c5fd935fbf