### PR TITLE
Update program status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,40 @@ docker compose up --build
 ```
 
 Adjust backend log verbosity via the `LOG_LEVEL` variable in `backend/.env`.
+
+## Checking Program Status
+
+After creating or editing a reseller program you can poll its status via
+`/v1/reseller/status/<program_id>`.  The endpoint returns details for each
+business that was updated.
+
+Example request:
+
+```
+GET https://partner-api.yelp.com/v1/reseller/status/LYhR2q1OsOd2KYsE2y67_A
+```
+
+Example response:
+
+```json
+{
+  "business_results": [
+    {
+      "status": "COMPLETED",
+      "identifier": "e2JTWqyUwRHXjpG8TCZ7Ow",
+      "identifier_type": "BUSINESS",
+      "update_results": {
+        "program_added": {
+          "yelp_business_id": {
+            "requested_value": "e2JTWqyUwRHXjpG8TCZ7Ow",
+            "status": "COMPLETED"
+          }
+        }
+      }
+    }
+  ],
+  "status": "COMPLETED",
+  "created_at": "2025-07-11T12:54:46+00:00",
+  "completed_at": "2025-07-11T12:55:44+00:00"
+}
+```

--- a/backend/ads/services.py
+++ b/backend/ads/services.py
@@ -60,8 +60,8 @@ class YelpService:
         return resp.json()
 
     @classmethod
-    def get_job_status(cls, job_id):
-        url = f'{cls.PARTNER_BASE}/v1/reseller/status/{job_id}'
+    def get_program_status(cls, program_id):
+        url = f'{cls.PARTNER_BASE}/v1/reseller/status/{program_id}'
         resp = requests.get(url, auth=cls.auth_partner)
         resp.raise_for_status()
         return resp.json()

--- a/backend/ads/urls.py
+++ b/backend/ads/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     path('reseller/program/create', CreateProgramView.as_view()),
     path('reseller/program/<str:program_id>/edit', EditProgramView.as_view()),
     path('reseller/program/<str:program_id>/end', TerminateProgramView.as_view()),
-    path('reseller/status/<str:job_id>', JobStatusView.as_view()),
+    path('reseller/status/<str:program_id>', JobStatusView.as_view()),
     path('reseller/programs', ProgramListView.as_view()),
     path('reseller/get_program_info', ProgramInfoView.as_view()),
 

--- a/backend/ads/views.py
+++ b/backend/ads/views.py
@@ -33,8 +33,8 @@ class TerminateProgramView(APIView):
         return Response(data)
 
 class JobStatusView(APIView):
-    def get(self, request, job_id):
-        data = YelpService.get_job_status(job_id)
+    def get(self, request, program_id):
+        data = YelpService.get_program_status(program_id)
         return Response(data)
 
 class RequestReportView(APIView):

--- a/frontend/src/components/JobStatusMonitor.tsx
+++ b/frontend/src/components/JobStatusMonitor.tsx
@@ -32,11 +32,12 @@ const JobStatusMonitor: React.FC = () => {
 
   const getStatusIcon = (status: string) => {
     switch (status) {
-      case 'pending':
+      case 'PENDING':
+      case 'IN_PROGRESS':
         return <Clock className="h-4 w-4" />;
-      case 'completed':
+      case 'COMPLETED':
         return <CheckCircle className="h-4 w-4" />;
-      case 'failed':
+      case 'FAILED':
         return <XCircle className="h-4 w-4" />;
       default:
         return <Loader2 className="h-4 w-4 animate-spin" />;
@@ -45,11 +46,12 @@ const JobStatusMonitor: React.FC = () => {
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'pending':
+      case 'PENDING':
+      case 'IN_PROGRESS':
         return 'bg-yellow-500';
-      case 'completed':
+      case 'COMPLETED':
         return 'bg-green-500';
-      case 'failed':
+      case 'FAILED':
         return 'bg-red-500';
       default:
         return 'bg-gray-500';
@@ -71,12 +73,12 @@ const JobStatusMonitor: React.FC = () => {
         <CardContent>
           <div className="flex gap-4 items-end">
             <div className="flex-1 space-y-2">
-              <Label htmlFor="job_id">Job ID</Label>
+              <Label htmlFor="job_id">Program/Job ID</Label>
               <Input
                 id="job_id"
                 value={jobId}
                 onChange={(e) => setJobId(e.target.value)}
-                placeholder="Введите Job ID для мониторинга"
+                placeholder="Введите ID программы для мониторинга"
               />
             </div>
             <div className="flex gap-2">
@@ -118,25 +120,25 @@ const JobStatusMonitor: React.FC = () => {
                   </Badge>
                 </div>
 
-                {jobStatus.status === 'completed' && jobStatus.result && (
+                {jobStatus.status === 'COMPLETED' && jobStatus.business_results && (
                   <div>
                     <h4 className="font-semibold mb-2">Результат:</h4>
                     <pre className="bg-gray-100 p-3 rounded text-sm overflow-auto">
-                      {JSON.stringify(jobStatus.result, null, 2)}
+                      {JSON.stringify(jobStatus.business_results, null, 2)}
                     </pre>
                   </div>
                 )}
 
-                {jobStatus.status === 'failed' && jobStatus.error_message && (
+                {jobStatus.status === 'FAILED' && (
                   <div>
                     <h4 className="font-semibold mb-2 text-red-600">Ошибка:</h4>
-                    <p className="text-red-600 bg-red-50 p-3 rounded">
-                      {jobStatus.error_message}
-                    </p>
+                    <pre className="text-red-600 bg-red-50 p-3 rounded">
+                      {JSON.stringify(jobStatus.business_results ?? {}, null, 2)}
+                    </pre>
                   </div>
                 )}
 
-                {jobStatus.status === 'pending' && (
+                {(jobStatus.status === 'PENDING' || jobStatus.status === 'IN_PROGRESS') && (
                   <div className="flex items-center gap-2 text-yellow-600">
                     <Loader2 className="h-4 w-4 animate-spin" />
                     <span>Задача выполняется... Обновление каждые 5 секунд</span>

--- a/frontend/src/store/api/yelpApi.ts
+++ b/frontend/src/store/api/yelpApi.ts
@@ -61,7 +61,7 @@ export const yelpApi = createApi({
 
     // 4. Проверить статус задачи
     getJobStatus: builder.query<JobStatus, string>({
-      query: (job_id) => `/reseller/status/${job_id}`,
+      query: (id) => `/reseller/status/${id}`,
       providesTags: ['JobStatus'],
     }),
 

--- a/frontend/src/types/yelp.ts
+++ b/frontend/src/types/yelp.ts
@@ -31,11 +31,29 @@ export interface EditProgramRequest {
   };
 }
 
+export interface FieldStatus {
+  requested_value: string;
+  status: 'COMPLETED' | 'FAILED';
+}
+
+export interface ProgramUpdateResults {
+  program_added?: Record<string, FieldStatus>;
+  program_updated?: Record<string, FieldStatus>;
+  program_deleted?: Record<string, FieldStatus>;
+}
+
+export interface BusinessResult {
+  status: 'COMPLETED' | 'FAILED';
+  identifier: string;
+  identifier_type: string;
+  update_results: ProgramUpdateResults;
+}
+
 export interface JobStatus {
-  job_id: string;
-  status: 'pending' | 'completed' | 'failed';
-  result?: any;
-  error_message?: string;
+  status: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED';
+  created_at: string;
+  completed_at?: string;
+  business_results: BusinessResult[];
 }
 
 export interface BusinessMatch {


### PR DESCRIPTION
## Summary
- document new reseller status endpoint
- handle updated response format in UI
- rename backend URL and service for program status
- adjust frontend types and monitoring component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - rest_framework)*

------
https://chatgpt.com/codex/tasks/task_e_687465a98488832d9567b05ba5ff078b