### PR TITLE
Display job status dialog on programs page

### DIFF
--- a/frontend/src/components/ProgramStatusDialog.tsx
+++ b/frontend/src/components/ProgramStatusDialog.tsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from 'react';
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Loader2, Clock, CheckCircle, XCircle } from 'lucide-react';
+import { useLazyGetJobStatusQuery } from '../store/api/yelpApi';
+
+interface ProgramStatusDialogProps {
+  jobId: string;
+}
+
+const ProgramStatusDialog: React.FC<ProgramStatusDialogProps> = ({ jobId }) => {
+  const [open, setOpen] = useState(false);
+  const [triggerFetch, { data, isLoading, error }] = useLazyGetJobStatusQuery();
+
+  useEffect(() => {
+    if (open) {
+      triggerFetch(jobId);
+    }
+  }, [open, jobId, triggerFetch]);
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'PENDING':
+      case 'IN_PROGRESS':
+        return <Clock className="h-4 w-4" />;
+      case 'COMPLETED':
+        return <CheckCircle className="h-4 w-4" />;
+      case 'FAILED':
+        return <XCircle className="h-4 w-4" />;
+      default:
+        return <Loader2 className="h-4 w-4 animate-spin" />;
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'PENDING':
+      case 'IN_PROGRESS':
+        return 'bg-yellow-500';
+      case 'COMPLETED':
+        return 'bg-green-500';
+      case 'FAILED':
+        return 'bg-red-500';
+      default:
+        return 'bg-gray-500';
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Clock className="h-4 w-4 mr-1" /> Статус
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Статус задачи: {jobId}</DialogTitle>
+        </DialogHeader>
+        {isLoading && (
+          <div className="flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Загрузка...</span>
+          </div>
+        )}
+        {error && <p className="text-red-500">Ошибка загрузки статуса</p>}
+        {data && (
+          <div className="space-y-4">
+            <Badge className={getStatusColor(data.status)}>
+              <span className="flex items-center gap-1">
+                {getStatusIcon(data.status)}
+                {data.status}
+              </span>
+            </Badge>
+            <pre className="bg-gray-100 p-3 rounded text-sm overflow-auto">
+              {JSON.stringify(data, null, 2)}
+            </pre>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ProgramStatusDialog;

--- a/frontend/src/components/ProgramsList.tsx
+++ b/frontend/src/components/ProgramsList.tsx
@@ -5,7 +5,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { toast } from '@/hooks/use-toast';
-import { Loader2, Edit, Trash2, Eye } from 'lucide-react';
+import { Loader2, Edit, Trash2, Eye, Clock } from 'lucide-react';
+import ProgramStatusDialog from './ProgramStatusDialog';
 import { useNavigate } from 'react-router-dom';
 
 const ProgramsList: React.FC = () => {
@@ -134,6 +135,7 @@ const ProgramsList: React.FC = () => {
                     <Edit className="h-4 w-4 mr-1" />
                     Редактировать
                   </Button>
+                  <ProgramStatusDialog jobId={program.program_id} />
                   <Button
                     variant="destructive"
                     size="sm"


### PR DESCRIPTION
## Summary
- add ProgramStatusDialog component to fetch `/reseller/status/<id>`
- show status dialog button for each program in the list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_6874707ee2d4832d8ee630de6867a920