### PR TITLE
Add logging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ containers. Any file changes automatically reload Django and Vite.
 docker compose up --build
 ```
 
+To continuously watch the output of both containers, run:
+
+```bash
+docker compose logs -f backend frontend
+```
+
 Adjust backend log verbosity via the `LOG_LEVEL` variable in `backend/.env`.
 
 ## Checking Program Status


### PR DESCRIPTION
## Summary
- document how to follow logs from both services when developing with Docker Compose

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687471c539fc832d9e5c8336f7d1974a