### PR TITLE
Fix missing lazy query export

### DIFF
--- a/frontend/src/store/api/yelpApi.ts
+++ b/frontend/src/store/api/yelpApi.ts
@@ -138,6 +138,7 @@ export const {
   useEditProgramMutation,
   useTerminateProgramMutation,
   useGetJobStatusQuery,
+  useLazyGetJobStatusQuery,
   useGetProgramsQuery,
   useGetProgramInfoQuery,
   useGetBusinessMatchesQuery,


### PR DESCRIPTION
## Summary
- export `useLazyGetJobStatusQuery` from `yelpApi`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68747b51de30832d807fc1cc475749e0