### PR TITLE
Add business ID programs lookup

### DIFF
--- a/backend/ads/services.py
+++ b/backend/ads/services.py
@@ -133,3 +133,11 @@ class YelpService:
         report.data = rows
         report.save()
         return rows
+
+    @classmethod
+    def get_business_programs(cls, business_id):
+        """Return advertising program info for a given business."""
+        url = f"{cls.PARTNER_BASE}/v1/reseller/businesses/{business_id}/programs"
+        resp = requests.get(url, auth=cls.auth_partner)
+        resp.raise_for_status()
+        return resp.json()

--- a/backend/ads/tests/test_views.py
+++ b/backend/ads/tests/test_views.py
@@ -42,3 +42,9 @@ def test_get_program_info(api_client):
     url = '/api/reseller/get_program_info'
     response = api_client.get(url)
     assert response.status_code in [200, 400, 404, 401]
+
+
+def test_get_business_programs(api_client):
+    url = '/api/reseller/business_programs/test'
+    response = api_client.get(url)
+    assert response.status_code in [200, 401]

--- a/backend/ads/urls.py
+++ b/backend/ads/urls.py
@@ -4,6 +4,7 @@ from .views import (
     EditProgramView,
     TerminateProgramView,
     JobStatusView,
+    BusinessProgramsView,
     BusinessMatchView,
     SyncSpecialtiesView,
     RequestReportView,
@@ -25,6 +26,7 @@ urlpatterns = [
     path('reseller/program/<str:program_id>/edit', EditProgramView.as_view()),
     path('reseller/program/<str:program_id>/end', TerminateProgramView.as_view()),
     path('reseller/status/<str:program_id>', JobStatusView.as_view()),
+    path('reseller/business_programs/<str:business_id>', BusinessProgramsView.as_view()),
     path('reseller/programs', ProgramListView.as_view()),
     path('reseller/get_program_info', ProgramInfoView.as_view()),
 

--- a/backend/ads/views.py
+++ b/backend/ads/views.py
@@ -37,6 +37,14 @@ class JobStatusView(APIView):
         data = YelpService.get_program_status(program_id)
         return Response(data)
 
+
+class BusinessProgramsView(APIView):
+    """Fetch advertising programs for a business."""
+
+    def get(self, request, business_id):
+        data = YelpService.get_business_programs(business_id)
+        return Response(data)
+
 class RequestReportView(APIView):
     def post(self, request, period):
         try:

--- a/frontend/src/components/ProgramsList.tsx
+++ b/frontend/src/components/ProgramsList.tsx
@@ -1,9 +1,10 @@
 
-import React from 'react';
-import { useGetProgramsQuery, useTerminateProgramMutation } from '../store/api/yelpApi';
+import React, { useState } from 'react';
+import { useGetProgramsQuery, useTerminateProgramMutation, useLazyGetBusinessProgramsQuery } from '../store/api/yelpApi';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
 import { toast } from '@/hooks/use-toast';
 import { Loader2, Edit, Trash2, Eye, Clock } from 'lucide-react';
 import ProgramStatusDialog from './ProgramStatusDialog';
@@ -12,6 +13,8 @@ import { useNavigate } from 'react-router-dom';
 const ProgramsList: React.FC = () => {
   const { data: programs, isLoading, error } = useGetProgramsQuery();
   const [terminateProgram] = useTerminateProgramMutation();
+  const [businessId, setBusinessId] = useState('');
+  const [fetchBusinessPrograms, { data: businessPrograms, isLoading: loadingBusiness, error: errorBusiness }] = useLazyGetBusinessProgramsQuery();
   const navigate = useNavigate();
 
   const handleTerminate = async (programId: string) => {
@@ -69,6 +72,41 @@ const ProgramsList: React.FC = () => {
           Создать программу
         </Button>
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Проверка Business ID</CardTitle>
+          <CardDescription>
+            Введите зашифрованный Business ID для просмотра программ
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-2 mb-4">
+            <Input
+              value={businessId}
+              onChange={(e) => setBusinessId(e.target.value)}
+              placeholder="J9R1gG5xy7DpWsCWBup7DQ"
+            />
+            <Button onClick={() => businessId && fetchBusinessPrograms(businessId)}>
+              Показать
+            </Button>
+          </div>
+          {loadingBusiness && (
+            <div className="flex items-center gap-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Загрузка...</span>
+            </div>
+          )}
+          {errorBusiness && (
+            <p className="text-red-500">Ошибка загрузки данных</p>
+          )}
+          {businessPrograms && (
+            <pre className="bg-gray-100 p-3 rounded text-sm overflow-auto">
+              {JSON.stringify(businessPrograms, null, 2)}
+            </pre>
+          )}
+        </CardContent>
+      </Card>
 
       {programs?.length === 0 ? (
         <Card>

--- a/frontend/src/store/api/yelpApi.ts
+++ b/frontend/src/store/api/yelpApi.ts
@@ -9,7 +9,8 @@ import {
   BusinessMatch,
   DailyReport,
   MonthlyReport,
-  BusinessUpdate
+  BusinessUpdate,
+  BusinessProgramsResponse
 } from '../../types/yelp';
 
 const baseQuery = fetchBaseQuery({
@@ -84,6 +85,11 @@ export const yelpApi = createApi({
       }),
     }),
 
+    // Получить программы для Business ID
+    getBusinessPrograms: builder.query<BusinessProgramsResponse, string>({
+      query: (business_id) => `/reseller/business_programs/${business_id}`,
+    }),
+
     // 7. Обновить категории бизнеса
     updateBusinessCategories: builder.mutation<{ job_id: string }, BusinessUpdate[]>({
       query: (businesses) => ({
@@ -142,6 +148,8 @@ export const {
   useGetProgramsQuery,
   useGetProgramInfoQuery,
   useGetBusinessMatchesQuery,
+  useGetBusinessProgramsQuery,
+  useLazyGetBusinessProgramsQuery,
   useUpdateBusinessCategoriesMutation,
   useRequestDailyReportMutation,
   useRequestMonthlyReportMutation,

--- a/frontend/src/types/yelp.ts
+++ b/frontend/src/types/yelp.ts
@@ -90,6 +90,39 @@ export interface MonthlyReport {
   data: ReportData[];
 }
 
+export interface BusinessProgram {
+  active_features: string[];
+  available_features: string[];
+  end_date: string;
+  program_id: string;
+  program_pause_status: string;
+  program_status: string;
+  program_type: string;
+  start_date: string;
+  program_metrics?: {
+    budget: number;
+    currency: string;
+    is_autobid: boolean;
+    max_bid: number | null;
+    fee_period: string;
+    billed_impressions: number;
+    billed_clicks: number;
+    ad_cost: number;
+  };
+  future_budget_changes: any[];
+}
+
+export interface BusinessProgramsResponse {
+  businesses: Array<{
+    yelp_business_id: string;
+    advertiser_status: string;
+    partner_business_id: string | null;
+    programs: BusinessProgram[];
+    destination_yelp_business_id: string | null;
+  }>;
+  errors: any[];
+}
+
 export interface BusinessUpdate {
   business_id: string;
   categories: string[];


### PR DESCRIPTION
## Summary
- allow users to query Yelp business program details
- expose backend endpoint for business program fetch
- update API store with new query hooks
- show results on the Programs page
- extend tests for new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_687495fd5af0832d91ffa336e22c94cc