### PR TITLE
Fix business program list endpoint

### DIFF
--- a/backend/ads/services.py
+++ b/backend/ads/services.py
@@ -136,8 +136,12 @@ class YelpService:
 
     @classmethod
     def get_business_programs(cls, business_id):
-        """Return advertising program info for a given business."""
-        url = f"{cls.PARTNER_BASE}/v1/reseller/businesses/{business_id}/programs"
+        """Return advertising program info for a given business.
+
+        This uses Yelp's ``/v1/programs/list/<business_id>`` endpoint which
+        requires the encrypted Yelp business identifier.
+        """
+        url = f"{cls.PARTNER_BASE}/v1/programs/list/{business_id}"
         resp = requests.get(url, auth=cls.auth_partner)
         resp.raise_for_status()
         return resp.json()


### PR DESCRIPTION
## Summary
- update YelpService URL for fetching business programs to use `/v1/programs/list/<business_id>`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68749c82553c832d8c51b07e89b30bd7