### PR TITLE
Fix Vite file watching with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ pytest
 Running `docker compose up` starts both services with source code mounted in the
 containers. Any file changes automatically reload Django and Vite.
 
+If file watching does not work on your system (for example on Windows or
+certain virtualized environments), Vite can be forced to poll for changes by
+setting the `CHOKIDAR_USEPOLLING` environment variable.  This repository already
+enables the variable in `docker-compose.yml` for convenience.
+
 ```bash
 docker compose up --build
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,11 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
-    environment:
-      - NODE_ENV=development
-    networks:
-      - app-network
+      environment:
+        - NODE_ENV=development
+        - CHOKIDAR_USEPOLLING=true
+      networks:
+        - app-network
 
 networks:
   app-network:


### PR DESCRIPTION
## Summary
- enable polling in the frontend container
- note CHOKIDAR_USEPOLLING in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68749f8809d4832d8073dcd2ac3639b3