### PR TITLE
Fix docker-compose YAML syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,11 +36,11 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
-      environment:
-        - NODE_ENV=development
-        - CHOKIDAR_USEPOLLING=true
-      networks:
-        - app-network
+    environment:
+      - NODE_ENV=development
+      - CHOKIDAR_USEPOLLING=true
+    networks:
+      - app-network
 
 networks:
   app-network:


### PR DESCRIPTION
## Summary
- fix indentation for the frontend service in `docker-compose.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*
- `pip install -q -r requirements.txt` *(fails: cannot connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_6874a27bb9f8832d807b097003d902b0