### PR TITLE
Improve business programs display

### DIFF
--- a/frontend/src/components/BusinessProgramsView.tsx
+++ b/frontend/src/components/BusinessProgramsView.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { BusinessProgramsResponse } from '../types/yelp';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from '@/components/ui/table';
+
+interface Props {
+  data: BusinessProgramsResponse;
+}
+
+const BusinessProgramsView: React.FC<Props> = ({ data }) => {
+  if (data.businesses.length === 0) {
+    return <p className="text-muted-foreground">Нет данных о программах</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {data.businesses.map((biz) => (
+        <Card key={biz.yelp_business_id}>
+          <CardHeader>
+            <CardTitle className="text-lg font-medium">{biz.yelp_business_id}</CardTitle>
+            <CardDescription>Статус рекламодателя: {biz.advertiser_status}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {biz.programs.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>ID программы</TableHead>
+                    <TableHead>Тип</TableHead>
+                    <TableHead>Статус</TableHead>
+                    <TableHead>Начало</TableHead>
+                    <TableHead>Конец</TableHead>
+                    <TableHead className="text-right">Бюджет</TableHead>
+                    <TableHead className="text-right">Клики</TableHead>
+                    <TableHead className="text-right">Показы</TableHead>
+                    <TableHead className="text-right">Стоимость</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {biz.programs.map((p) => (
+                    <TableRow key={p.program_id}>
+                      <TableCell className="font-mono text-xs">{p.program_id}</TableCell>
+                      <TableCell>{p.program_type}</TableCell>
+                      <TableCell>{p.program_status}</TableCell>
+                      <TableCell>{p.start_date}</TableCell>
+                      <TableCell>{p.end_date}</TableCell>
+                      <TableCell className="text-right">
+                        {p.program_metrics?.budget ?? '-'}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {p.program_metrics?.billed_clicks ?? '-'}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {p.program_metrics?.billed_impressions ?? '-'}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {p.program_metrics?.ad_cost ?? '-'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <p className="text-muted-foreground">Нет программ для этого бизнеса</p>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default BusinessProgramsView;

--- a/frontend/src/components/ProgramsList.tsx
+++ b/frontend/src/components/ProgramsList.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { toast } from '@/hooks/use-toast';
 import { Loader2, Edit, Trash2, Eye, Clock } from 'lucide-react';
 import ProgramStatusDialog from './ProgramStatusDialog';
+import BusinessProgramsView from './BusinessProgramsView';
 import { useNavigate } from 'react-router-dom';
 
 const ProgramsList: React.FC = () => {
@@ -100,11 +101,7 @@ const ProgramsList: React.FC = () => {
           {errorBusiness && (
             <p className="text-red-500">Ошибка загрузки данных</p>
           )}
-          {businessPrograms && (
-            <pre className="bg-gray-100 p-3 rounded text-sm overflow-auto">
-              {JSON.stringify(businessPrograms, null, 2)}
-            </pre>
-          )}
+          {businessPrograms && <BusinessProgramsView data={businessPrograms} />}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- add `BusinessProgramsView` component to render business program data as table
- show `BusinessProgramsView` in Programs list page instead of raw JSON

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874a4587650832d875c840d964c9954