### PR TITLE
Add advanced program edit page

### DIFF
--- a/backend/ads/serializers.py
+++ b/backend/ads/serializers.py
@@ -8,6 +8,8 @@ class ProgramSerializer(serializers.ModelSerializer):
     created_date = serializers.DateTimeField(source='created_at')
     modified_date = serializers.DateTimeField(source='updated_at')
     business_id = serializers.SerializerMethodField()
+    start_date = serializers.DateField()
+    end_date = serializers.DateField(allow_null=True)
 
     def get_business_id(self, obj):
         return ''
@@ -22,6 +24,8 @@ class ProgramSerializer(serializers.ModelSerializer):
             'created_date',
             'modified_date',
             'budget_amount',
+            'start_date',
+            'end_date',
         ]
 
 class ReportSerializer(serializers.ModelSerializer):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import Dashboard from './components/Dashboard';
 import JobStatusMonitor from './components/JobStatusMonitor';
 import CategoryManager from './components/CategoryManager';
 import ProgramDetails from './pages/ProgramDetails';
+import EditAdvancedProgram from './pages/EditAdvancedProgram';
 import Login from './pages/Login';
 import NotFound from "./pages/NotFound";
 
@@ -30,6 +31,7 @@ const App = () => (
             <Route index element={<Index />} />
             <Route path="create" element={<CreateProgram />} />
             <Route path="edit/:programId" element={<EditProgram />} />
+            <Route path="edit-advanced/:programId" element={<EditAdvancedProgram />} />
             <Route path="programs" element={<ProgramsList />} />
             <Route path="program/:programId" element={<ProgramDetails />} />
             <Route path="search" element={<BusinessSearch />} />

--- a/frontend/src/components/ProgramsList.tsx
+++ b/frontend/src/components/ProgramsList.tsx
@@ -170,6 +170,15 @@ const ProgramsList: React.FC = () => {
                     <Edit className="h-4 w-4 mr-1" />
                     Редактировать
                   </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => navigate(`/edit-advanced/${program.program_id}`)}
+                    disabled={program.status === 'terminated'}
+                  >
+                    <Edit className="h-4 w-4 mr-1" />
+                    Расширенно
+                  </Button>
                   <ProgramStatusDialog jobId={program.program_id} />
                   <Button
                     variant="destructive"

--- a/frontend/src/pages/EditAdvancedProgram.tsx
+++ b/frontend/src/pages/EditAdvancedProgram.tsx
@@ -1,0 +1,144 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useEditProgramMutation, useGetProgramInfoQuery } from '../store/api/yelpApi';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { toast } from '@/hooks/use-toast';
+import { Loader2 } from 'lucide-react';
+
+const EditAdvancedProgram: React.FC = () => {
+  const { programId } = useParams<{ programId: string }>();
+  const navigate = useNavigate();
+  const [editProgram, { isLoading }] = useEditProgramMutation();
+  const { data: program } = useGetProgramInfoQuery(programId || '', { skip: !programId });
+
+  const [form, setForm] = useState({
+    start: '',
+    end: '',
+    budget: '',
+    future_budget_date: '',
+    max_bid: '',
+    pacing_method: 'paced',
+    ad_categories: ''
+  });
+
+  useEffect(() => {
+    if (program) {
+      if (program.start_date) setForm(f => ({ ...f, start: program.start_date }));
+      if (program.end_date) setForm(f => ({ ...f, end: program.end_date }));
+      if (program.budget_amount !== undefined && program.budget_amount !== null) {
+        setForm(f => ({ ...f, budget: String(program.budget_amount) }));
+      }
+      if (program.targeting?.categories) {
+        setForm(f => ({ ...f, ad_categories: program.targeting.categories.join(', ') }));
+      }
+    }
+  }, [program]);
+
+  const handleChange = (field: string, value: string) => {
+    setForm(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!programId) return;
+    try {
+      const result = await editProgram({
+        program_id: programId,
+        data: {
+          start: form.start || undefined,
+          end: form.end || undefined,
+          budget: form.budget ? parseInt(form.budget, 10) : undefined,
+          future_budget_date: form.future_budget_date || undefined,
+          max_bid: form.max_bid ? parseInt(form.max_bid, 10) : undefined,
+          pacing_method: form.pacing_method || undefined,
+          ad_categories: form.ad_categories
+            ? form.ad_categories.split(',').map(c => c.trim()).filter(Boolean)
+            : undefined,
+        },
+      }).unwrap();
+
+      toast({
+        title: 'Программа обновляется',
+        description: `Job ID: ${result.job_id}`,
+      });
+
+      navigate('/programs');
+    } catch (error) {
+      toast({
+        title: 'Ошибка редактирования программы',
+        description: 'Проверьте введенные данные',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  if (!programId) {
+    return <p className="text-red-500">Program ID не указан</p>;
+  }
+
+  return (
+    <Card className="w-full max-w-2xl mx-auto">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">Расширенное редактирование</CardTitle>
+        <CardDescription>Измените параметры CPC-программы</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="start">Start Date</Label>
+            <Input id="start" type="date" value={form.start}
+              onChange={e => handleChange('start', e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="end">End Date</Label>
+            <Input id="end" type="date" value={form.end}
+              onChange={e => handleChange('end', e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="budget">Monthly Budget (cents)</Label>
+            <Input id="budget" type="number" value={form.budget}
+              onChange={e => handleChange('budget', e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="future_budget_date">Future Budget Start</Label>
+            <Input id="future_budget_date" type="date" value={form.future_budget_date}
+              onChange={e => handleChange('future_budget_date', e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="max_bid">Max Bid (cents)</Label>
+            <Input id="max_bid" type="number" value={form.max_bid}
+              onChange={e => handleChange('max_bid', e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="pacing_method">Pacing Method</Label>
+            <select id="pacing_method" className="w-full border rounded p-2" value={form.pacing_method}
+              onChange={e => handleChange('pacing_method', e.target.value)}>
+              <option value="paced">paced</option>
+              <option value="unpaced">unpaced</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ad_categories">Ad Categories</Label>
+            <Input id="ad_categories" value={form.ad_categories}
+              onChange={e => handleChange('ad_categories', e.target.value)} placeholder="cat1, cat2" />
+          </div>
+          <Button type="submit" disabled={isLoading} className="w-full">
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Сохранение...
+              </>
+            ) : (
+              'Сохранить'
+            )}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default EditAdvancedProgram;

--- a/frontend/src/types/yelp.ts
+++ b/frontend/src/types/yelp.ts
@@ -7,6 +7,8 @@ export interface Program {
   created_date: string;
   modified_date: string;
   budget_amount?: number;
+  start_date?: string;
+  end_date?: string | null;
   targeting?: {
     locations?: string[];
     categories?: string[];
@@ -24,11 +26,21 @@ export interface CreateProgramRequest {
 }
 
 export interface EditProgramRequest {
+  // Legacy fields used by the basic EditProgram page
   budget_amount?: number;
   targeting?: {
     locations?: string[];
     categories?: string[];
   };
+
+  // Fields supported by the Yelp program edit endpoint
+  start?: string;
+  end?: string;
+  budget?: number;
+  future_budget_date?: string;
+  max_bid?: number;
+  pacing_method?: 'paced' | 'unpaced';
+  ad_categories?: string[];
 }
 
 export interface FieldStatus {


### PR DESCRIPTION
## Summary
- show start/end dates in backend Program serializer
- extend program types for additional fields
- add advanced program editing page and routing
- expose advanced edit option in Programs list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_6874bf711438832d91009cfbe9d24456