### PR TITLE
Add advanced edit link to sidebar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ const App = () => (
             <Route index element={<Index />} />
             <Route path="create" element={<CreateProgram />} />
             <Route path="edit/:programId" element={<EditProgram />} />
+            <Route path="edit-advanced" element={<EditAdvancedProgram />} />
             <Route path="edit-advanced/:programId" element={<EditAdvancedProgram />} />
             <Route path="programs" element={<ProgramsList />} />
             <Route path="program/:programId" element={<ProgramDetails />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,14 +3,15 @@ import React from 'react';
 import { Outlet, Link, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { 
-  Home, 
-  Plus, 
-  List, 
-  Search, 
-  BarChart3, 
-  Clock, 
+  Home,
+  Plus,
+  List,
+  Search,
+  BarChart3,
+  Clock,
   Settings,
-  Menu
+  Menu,
+  Edit
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -22,6 +23,7 @@ const Layout: React.FC = () => {
     { name: 'Главная', href: '/', icon: Home },
     { name: 'Создать программу', href: '/create', icon: Plus },
     { name: 'Программы', href: '/programs', icon: List },
+    { name: 'Расширенное редактирование', href: '/edit-advanced', icon: Edit },
     { name: 'Поиск бизнесов', href: '/search', icon: Search },
     { name: 'Аналитика', href: '/dashboard', icon: BarChart3 },
     { name: 'Мониторинг задач', href: '/jobs', icon: Clock },


### PR DESCRIPTION
## Summary
- link advanced edit page from the sidebar navigation
- handle `/edit-advanced` route without an ID

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_6874c56505d8832d893f4934ddd00986