### PR TITLE
Simplify programs listing

### DIFF
--- a/backend/ads/services.py
+++ b/backend/ads/services.py
@@ -134,14 +134,3 @@ class YelpService:
         report.save()
         return rows
 
-    @classmethod
-    def get_business_programs(cls, business_id):
-        """Return advertising program info for a given business.
-
-        This uses Yelp's ``/v1/programs/list/<business_id>`` endpoint which
-        requires the encrypted Yelp business identifier.
-        """
-        url = f"{cls.PARTNER_BASE}/v1/programs/list/{business_id}"
-        resp = requests.get(url, auth=cls.auth_partner)
-        resp.raise_for_status()
-        return resp.json()

--- a/backend/ads/tests/test_views.py
+++ b/backend/ads/tests/test_views.py
@@ -44,7 +44,3 @@ def test_get_program_info(api_client):
     assert response.status_code in [200, 400, 404, 401]
 
 
-def test_get_business_programs(api_client):
-    url = '/api/reseller/business_programs/test'
-    response = api_client.get(url)
-    assert response.status_code in [200, 401]

--- a/backend/ads/urls.py
+++ b/backend/ads/urls.py
@@ -4,7 +4,6 @@ from .views import (
     EditProgramView,
     TerminateProgramView,
     JobStatusView,
-    BusinessProgramsView,
     BusinessMatchView,
     SyncSpecialtiesView,
     RequestReportView,
@@ -26,7 +25,6 @@ urlpatterns = [
     path('reseller/program/<str:program_id>/edit', EditProgramView.as_view()),
     path('reseller/program/<str:program_id>/end', TerminateProgramView.as_view()),
     path('reseller/status/<str:program_id>', JobStatusView.as_view()),
-    path('reseller/business_programs/<str:business_id>', BusinessProgramsView.as_view()),
     path('reseller/programs', ProgramListView.as_view()),
     path('reseller/get_program_info', ProgramInfoView.as_view()),
 

--- a/backend/ads/views.py
+++ b/backend/ads/views.py
@@ -38,12 +38,6 @@ class JobStatusView(APIView):
         return Response(data)
 
 
-class BusinessProgramsView(APIView):
-    """Fetch advertising programs for a business."""
-
-    def get(self, request, business_id):
-        data = YelpService.get_business_programs(business_id)
-        return Response(data)
 
 class RequestReportView(APIView):
     def post(self, request, period):

--- a/frontend/src/components/ProgramsList.tsx
+++ b/frontend/src/components/ProgramsList.tsx
@@ -1,51 +1,13 @@
-
-import React, { useState } from 'react';
-import { useGetProgramsQuery, useTerminateProgramMutation, useLazyGetBusinessProgramsQuery } from '../store/api/yelpApi';
+import React from 'react';
+import { useGetProgramsQuery } from '../store/api/yelpApi';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { toast } from '@/hooks/use-toast';
-import { Loader2, Edit, Trash2, Eye, Clock } from 'lucide-react';
-import ProgramStatusDialog from './ProgramStatusDialog';
-import BusinessProgramsView from './BusinessProgramsView';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useNavigate } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
 
 const ProgramsList: React.FC = () => {
   const { data: programs, isLoading, error } = useGetProgramsQuery();
-  const [terminateProgram] = useTerminateProgramMutation();
-  const [businessId, setBusinessId] = useState('');
-  const [fetchBusinessPrograms, { data: businessPrograms, isLoading: loadingBusiness, error: errorBusiness }] = useLazyGetBusinessProgramsQuery();
   const navigate = useNavigate();
-
-  const handleTerminate = async (programId: string) => {
-    try {
-      const result = await terminateProgram(programId).unwrap();
-      toast({
-        title: "Программа завершается",
-        description: `Job ID: ${result.job_id}`,
-      });
-    } catch (error) {
-      toast({
-        title: "Ошибка завершения программы",
-        description: "Попробуйте еще раз",
-        variant: "destructive",
-      });
-    }
-  };
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'active':
-        return 'bg-green-500';
-      case 'paused':
-        return 'bg-yellow-500';
-      case 'terminated':
-        return 'bg-red-500';
-      default:
-        return 'bg-gray-500';
-    }
-  };
 
   if (isLoading) {
     return (
@@ -69,41 +31,8 @@ const ProgramsList: React.FC = () => {
     <div className="space-y-4">
       <div className="flex justify-between items-center">
         <h2 className="text-2xl font-bold">Рекламные программы</h2>
-        <Button onClick={() => navigate('/create')}>
-          Создать программу
-        </Button>
+        <Button onClick={() => navigate('/create')}>Создать программу</Button>
       </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Проверка Business ID</CardTitle>
-          <CardDescription>
-            Введите зашифрованный Business ID для просмотра программ
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex gap-2 mb-4">
-            <Input
-              value={businessId}
-              onChange={(e) => setBusinessId(e.target.value)}
-              placeholder="J9R1gG5xy7DpWsCWBup7DQ"
-            />
-            <Button onClick={() => businessId && fetchBusinessPrograms(businessId)}>
-              Показать
-            </Button>
-          </div>
-          {loadingBusiness && (
-            <div className="flex items-center gap-2">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              <span>Загрузка...</span>
-            </div>
-          )}
-          {errorBusiness && (
-            <p className="text-red-500">Ошибка загрузки данных</p>
-          )}
-          {businessPrograms && <BusinessProgramsView data={businessPrograms} />}
-        </CardContent>
-      </Card>
 
       {programs?.length === 0 ? (
         <Card>
@@ -118,78 +47,17 @@ const ProgramsList: React.FC = () => {
           {programs?.map((program) => (
             <Card key={program.program_id}>
               <CardHeader>
-                <div className="flex justify-between items-start">
-                  <div>
-                    <CardTitle className="text-lg">
-                      {program.product_type}
-                    </CardTitle>
-                    <CardDescription>
-                      ID: {program.program_id}
-                    </CardDescription>
-                  </div>
-                  <Badge className={getStatusColor(program.status)}>
-                    {program.status}
-                  </Badge>
-                </div>
+                <CardTitle className="text-lg">
+                  {program.product_type} (ID: {program.program_id})
+                </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="grid grid-cols-2 gap-4 mb-4">
-                  <div>
-                    <p className="text-sm text-muted-foreground">Business ID</p>
-                    <p className="font-mono text-sm">{program.business_id}</p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Бюджет</p>
-                    <p className="font-medium">${program.budget_amount || 'N/A'}</p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Создано</p>
-                    <p className="text-sm">{new Date(program.created_date).toLocaleDateString()}</p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Изменено</p>
-                    <p className="text-sm">{new Date(program.modified_date).toLocaleDateString()}</p>
-                  </div>
-                </div>
-
-                <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => navigate(`/program/${program.program_id}`)}
-                  >
-                    <Eye className="h-4 w-4 mr-1" />
-                    Просмотр
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => navigate(`/edit/${program.program_id}`)}
-                    disabled={program.status === 'terminated'}
-                  >
-                    <Edit className="h-4 w-4 mr-1" />
-                    Редактировать
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => navigate(`/edit-advanced/${program.program_id}`)}
-                    disabled={program.status === 'terminated'}
-                  >
-                    <Edit className="h-4 w-4 mr-1" />
-                    Расширенно
-                  </Button>
-                  <ProgramStatusDialog jobId={program.program_id} />
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    onClick={() => handleTerminate(program.program_id)}
-                    disabled={program.status === 'terminated'}
-                  >
-                    <Trash2 className="h-4 w-4 mr-1" />
-                    Завершить
-                  </Button>
-                </div>
+                <p className="text-sm text-muted-foreground">
+                  Статус: {program.status}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Бюджет: ${program.budget_amount || 'N/A'}
+                </p>
               </CardContent>
             </Card>
           ))}


### PR DESCRIPTION
## Summary
- remove `BusinessProgramsView` API and related tests
- simplify `/programs` front‑end page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_6874db6efcec832db9da3695dcaf5f87