### PR TITLE
Add partner program info view

### DIFF
--- a/backend/ads/services.py
+++ b/backend/ads/services.py
@@ -149,3 +149,11 @@ class YelpService:
         resp.raise_for_status()
         return resp.json()
 
+    @classmethod
+    def get_program_info(cls, program_id):
+        """Return detailed information for a specific program."""
+        url = f'{cls.PARTNER_BASE}/v1/programs/info/{program_id}'
+        resp = requests.get(url, auth=cls._get_partner_auth())
+        resp.raise_for_status()
+        return resp.json()
+

--- a/backend/ads/urls.py
+++ b/backend/ads/urls.py
@@ -11,6 +11,7 @@ from .views import (
     ProgramListView,
     ProgramInfoView,
     BusinessProgramsView,
+    PartnerProgramInfoView,
 )
 
 urlpatterns = [
@@ -29,6 +30,7 @@ urlpatterns = [
     path('reseller/programs', ProgramListView.as_view()),
     path('reseller/get_program_info', ProgramInfoView.as_view()),
     path('reseller/business_programs/<str:business_id>', BusinessProgramsView.as_view()),
+    path('reseller/program_info/<str:program_id>', PartnerProgramInfoView.as_view()),
 
     re_path(r'^reporting/businesses/(?P<period>[^/]+)/?$', RequestReportView.as_view()),
     re_path(r'^reporting/businesses/(?P<period>[^/]+)/(?P<report_id>[^/]+)/?$', FetchReportView.as_view()),

--- a/backend/ads/views.py
+++ b/backend/ads/views.py
@@ -85,3 +85,11 @@ class BusinessProgramsView(APIView):
     def get(self, request, business_id):
         data = YelpService.get_business_programs(business_id)
         return Response(data)
+
+
+class PartnerProgramInfoView(APIView):
+    """Return program info from Yelp for a specific program id."""
+
+    def get(self, request, program_id):
+        data = YelpService.get_program_info(program_id)
+        return Response(data)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import ProgramsList from './components/ProgramsList';
 import JobStatusMonitor from './components/JobStatusMonitor';
 import ProgramDetails from './pages/ProgramDetails';
 import BusinessProgramsInfo from './pages/BusinessProgramsInfo';
+import PartnerProgramInfo from './pages/PartnerProgramInfo';
 import EditAdvancedProgram from './pages/EditAdvancedProgram';
 import Login from './pages/Login';
 import NotFound from "./pages/NotFound";
@@ -33,6 +34,7 @@ const App = () => (
             <Route path="edit-advanced/:programId" element={<EditAdvancedProgram />} />
             <Route path="programs" element={<ProgramsList />} />
             <Route path="program/:programId" element={<ProgramDetails />} />
+            <Route path="program-info/:programId" element={<PartnerProgramInfo />} />
             <Route path="business-programs/:businessId" element={<BusinessProgramsInfo />} />
             <Route path="jobs" element={<JobStatusMonitor />} />
           </Route>

--- a/frontend/src/components/ProgramsList.tsx
+++ b/frontend/src/components/ProgramsList.tsx
@@ -60,14 +60,12 @@ const ProgramsList: React.FC = () => {
                 <p className="text-sm text-muted-foreground">
                   Бюджет: ${program.budget_amount || 'N/A'}
                 </p>
-                {program.business_id && (
-                  <Button
-                    size="sm"
-                    onClick={() => navigate(`/business-programs/${program.business_id}`)}
-                  >
-                    Переглянути інформацію
-                  </Button>
-                )}
+                <Button
+                  size="sm"
+                  onClick={() => navigate(`/program-info/${program.program_id}`)}
+                >
+                  Переглянути інформацію
+                </Button>
               </CardContent>
             </Card>
           ))}

--- a/frontend/src/pages/PartnerProgramInfo.tsx
+++ b/frontend/src/pages/PartnerProgramInfo.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useGetPartnerProgramInfoQuery } from '../store/api/yelpApi';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
+
+const PartnerProgramInfo: React.FC = () => {
+  const { programId } = useParams<{ programId: string }>();
+  const navigate = useNavigate();
+
+  const { data, isLoading, error } = useGetPartnerProgramInfoQuery(programId || '', {
+    skip: !programId,
+  });
+
+  if (!programId) {
+    return <p className="text-red-500">Program ID не указан</p>;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (error || !data || data.programs.length === 0) {
+    return (
+      <div className="space-y-4 max-w-2xl mx-auto">
+        <Button variant="outline" onClick={() => navigate(-1)}>
+          Назад
+        </Button>
+        <p className="text-red-500">Ошибка загрузки данных программы</p>
+      </div>
+    );
+  }
+
+  const program = data.programs[0];
+
+  return (
+    <div className="space-y-4 max-w-2xl mx-auto">
+      <Button variant="outline" onClick={() => navigate(-1)}>
+        Назад
+      </Button>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">{program.program_type}</CardTitle>
+          <CardDescription>ID: {program.program_id}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div>
+            <p className="text-sm text-muted-foreground">Business ID</p>
+            <p className="font-mono text-sm">{program.yelp_business_id}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Статус</p>
+            <p className="font-medium">{program.program_status}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Пауза</p>
+            <p className="font-medium">{program.program_pause_status}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Начало</p>
+            <p className="font-medium">{program.start_date}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Конец</p>
+            <p className="font-medium">{program.end_date}</p>
+          </div>
+          {program.program_metrics && (
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">Бюджет</p>
+              <p className="font-medium">{program.program_metrics.budget}</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default PartnerProgramInfo;

--- a/frontend/src/store/api/yelpApi.ts
+++ b/frontend/src/store/api/yelpApi.ts
@@ -10,7 +10,8 @@ import {
   DailyReport,
   MonthlyReport,
   BusinessUpdate,
-  BusinessProgramsResponse
+  BusinessProgramsResponse,
+  ProgramInfoResponse,
 } from '../../types/yelp';
 
 const baseQuery = fetchBaseQuery({
@@ -90,6 +91,11 @@ export const yelpApi = createApi({
       query: (business_id) => `/reseller/business_programs/${business_id}`,
     }),
 
+    // Получить информацию о программе по её ID
+    getPartnerProgramInfo: builder.query<ProgramInfoResponse, string>({
+      query: (program_id) => `/reseller/program_info/${program_id}`,
+    }),
+
     // 7. Обновить категории бизнеса
     updateBusinessCategories: builder.mutation<{ job_id: string }, BusinessUpdate[]>({
       query: (businesses) => ({
@@ -150,6 +156,7 @@ export const {
   useGetBusinessMatchesQuery,
   useGetBusinessProgramsQuery,
   useLazyGetBusinessProgramsQuery,
+  useGetPartnerProgramInfoQuery,
   useUpdateBusinessCategoriesMutation,
   useRequestDailyReportMutation,
   useRequestMonthlyReportMutation,

--- a/frontend/src/types/yelp.ts
+++ b/frontend/src/types/yelp.ts
@@ -135,6 +135,11 @@ export interface BusinessProgramsResponse {
   errors: any[];
 }
 
+export interface ProgramInfoResponse {
+  programs: BusinessProgram[];
+  errors: any[];
+}
+
 export interface BusinessUpdate {
   business_id: string;
   categories: string[];


### PR DESCRIPTION
## Summary
- enable fetching Yelp program info by program ID
- expose new backend endpoint `/reseller/program_info/<program_id>`
- create `PartnerProgramInfo` frontend page
- show a 'Переглянути інформацію' button for each program that opens the new page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_6874fc0b52b0832db5fac4baf4053955