### PR TITLE
Implement program status display page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import JobStatusMonitor from './components/JobStatusMonitor';
 import ProgramDetails from './pages/ProgramDetails';
 import BusinessProgramsInfo from './pages/BusinessProgramsInfo';
 import PartnerProgramInfo from './pages/PartnerProgramInfo';
+import ProgramStatus from './pages/ProgramStatus';
 import EditAdvancedProgram from './pages/EditAdvancedProgram';
 import Login from './pages/Login';
 import NotFound from "./pages/NotFound";
@@ -35,6 +36,7 @@ const App = () => (
             <Route path="programs" element={<ProgramsList />} />
             <Route path="program/:programId" element={<ProgramDetails />} />
             <Route path="program-info/:programId" element={<PartnerProgramInfo />} />
+            <Route path="program-status/:programId" element={<ProgramStatus />} />
             <Route path="business-programs/:businessId" element={<BusinessProgramsInfo />} />
             <Route path="jobs" element={<JobStatusMonitor />} />
           </Route>

--- a/frontend/src/components/ProgramsList.tsx
+++ b/frontend/src/components/ProgramsList.tsx
@@ -62,7 +62,7 @@ const ProgramsList: React.FC = () => {
                 </p>
                 <Button
                   size="sm"
-                  onClick={() => navigate(`/program-info/${program.program_id}`)}
+                  onClick={() => navigate(`/program-status/${program.program_id}`)}
                 >
                   Переглянути інформацію
                 </Button>

--- a/frontend/src/pages/ProgramStatus.tsx
+++ b/frontend/src/pages/ProgramStatus.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useGetJobStatusQuery } from '../store/api/yelpApi';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
+
+const ProgramStatus: React.FC = () => {
+  const { programId } = useParams<{ programId: string }>();
+  const navigate = useNavigate();
+
+  const { data, isLoading, error } = useGetJobStatusQuery(programId || '', {
+    skip: !programId,
+  });
+
+  if (!programId) {
+    return <p className="text-red-500">Program ID не указан</p>;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="space-y-4 max-w-2xl mx-auto">
+        <Button variant="outline" onClick={() => navigate(-1)}>
+          Назад
+        </Button>
+        <p className="text-red-500">Ошибка загрузки статуса программы</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 max-w-2xl mx-auto">
+      <Button variant="outline" onClick={() => navigate(-1)}>
+        Назад
+      </Button>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Статус программы</CardTitle>
+          <CardDescription>ID: {programId}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <pre className="bg-gray-100 p-3 rounded text-sm overflow-auto">
+            {JSON.stringify(data, null, 2)}
+          </pre>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ProgramStatus;


### PR DESCRIPTION
## Summary
- add `ProgramStatus` page for displaying reseller status JSON
- link ProgramsList button to new status page
- register route for status page in the router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_687501558318832dbf9f47bfa9ade626