### PR TITLE
Ensure program is active before termination

### DIFF
--- a/backend/ads/tests/test_views.py
+++ b/backend/ads/tests/test_views.py
@@ -58,3 +58,9 @@ def test_resume_program(api_client):
     assert response.status_code in [202, 401, 404]
 
 
+def test_terminate_program(api_client):
+    url = '/api/reseller/program/123/end'
+    response = api_client.post(url)
+    assert response.status_code in [200, 400, 404, 401]
+
+

--- a/backend/ads/views.py
+++ b/backend/ads/views.py
@@ -62,6 +62,14 @@ class TerminateProgramView(APIView):
         logger.info(f"Terminating program {program_id}")
         try:
             data = YelpService.terminate_program(program_id)
+            detail = data.get("detail") if isinstance(data, dict) else None
+            if detail:
+                logger.warning(f"Program {program_id} not terminated: {detail}")
+                status_map = {
+                    "PROGRAM_HAS_EXPIRED": status.HTTP_400_BAD_REQUEST,
+                    "PROGRAM_NOT_FOUND": status.HTTP_404_NOT_FOUND,
+                }
+                return Response({"detail": detail}, status=status_map.get(detail, status.HTTP_400_BAD_REQUEST))
             logger.info(f"Program {program_id} terminated successfully")
             return Response(data)
         except Exception as e:


### PR DESCRIPTION
## Summary
- add `validate_program_active` helper to verify programs are active
- use validation in `terminate_program` and return informative detail when inactive
- surface inactive program messages through API view and add terminate test

## Testing
- `DATABASE_URL=sqlite:///db.sqlite3 pytest --ds=backend.settings` *(fails: ProxyError: HTTPSConnectionPool host='partner-api.yelp.com' 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a692e1bfa4832d9fd4b4f28ea25a39