### PR TITLE
Update Yelp program pause/resume endpoints

### DIFF
--- a/backend/ads/services.py
+++ b/backend/ads/services.py
@@ -204,14 +204,14 @@ class YelpService:
 
     @classmethod
     def pause_program(cls, program_id):
-        url = f'{cls.PARTNER_BASE}/program/{program_id}/pause/v1'
+        url = f'{cls.PARTNER_BASE}/v1/reseller/program/{program_id}/pause'
         resp = requests.post(url, auth=cls._get_partner_auth())
         resp.raise_for_status()
         return {'status': resp.status_code}
 
     @classmethod
     def resume_program(cls, program_id):
-        url = f'{cls.PARTNER_BASE}/program/{program_id}/resume/v1'
+        url = f'{cls.PARTNER_BASE}/v1/reseller/program/{program_id}/resume'
         resp = requests.post(url, auth=cls._get_partner_auth())
         resp.raise_for_status()
         return {'status': resp.status_code}


### PR DESCRIPTION
## Summary
- point Yelp program pause and resume methods to `/v1/reseller/program/{program_id}/pause` and `/v1/reseller/program/{program_id}/resume`

## Testing
- `PYTHONPATH=backend DJANGO_SETTINGS_MODULE=backend.settings DATABASE_URL=sqlite:/// pytest backend/ads/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a6c654ca90832db90ac1eddd5c5d05