### PR TITLE
Fix JSX closing tags in ProgramsList component

### DIFF
--- a/frontend/src/components/ProgramsList.tsx
+++ b/frontend/src/components/ProgramsList.tsx
@@ -639,12 +639,13 @@ const ProgramsList: React.FC = () => {
                     </div>
                   );
                 }
-                return null;
+              return null;
               })()}
             </div>
           )}
         </div>
-      </div>
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- fix mismatched JSX structure in `ProgramsList` causing React SWC parsing error

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ad828d5cf0832d99ffa2f524eee858