### PR TITLE
Format feature type names in UI

### DIFF
--- a/frontend/src/components/FeatureEditors/FeatureEditorManager.tsx
+++ b/frontend/src/components/FeatureEditors/FeatureEditorManager.tsx
@@ -12,6 +12,7 @@ import CustomAdPhotoEditor from './CustomAdPhotoEditor';
 import YelpPortfolioEditor from './YelpPortfolioEditor';
 import { Card, CardContent } from '@/components/ui/card';
 import { AlertTriangle } from 'lucide-react';
+import { formatFeatureType } from '@/lib/utils';
 
 export type FeatureType = 
   | 'LINK_TRACKING'
@@ -207,7 +208,7 @@ const FeatureEditorManager: React.FC<FeatureEditorManagerProps> = ({
       <DialogContent className="max-w-fit max-h-[90vh] overflow-y-auto" aria-describedby="feature-editor-description">
         <DialogHeader>
           <DialogTitle>
-            Feature settings: {featureType?.replace(/_/g, ' ')}
+            Feature settings: {featureType && formatFeatureType(featureType)}
           </DialogTitle>
         </DialogHeader>
         <div id="feature-editor-description" className="sr-only">

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,6 +5,14 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function formatFeatureType(featureType: string): string {
+  return featureType
+    .toLowerCase()
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 // Yelp API Error Codes mapping to user-friendly messages
 const errorMap: Record<string, { title: string; description: string; actionRequired: boolean }> = {
   // Critical Errors

--- a/frontend/src/pages/ProgramFeatures.tsx
+++ b/frontend/src/pages/ProgramFeatures.tsx
@@ -16,6 +16,7 @@ import {
   Target, Shield, Star, Award, Link, FolderOpen
 } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
+import { formatFeatureType } from '@/lib/utils';
 
 // Detailed descriptions of all Program Features types according to Yelp documentation
 const FEATURE_DESCRIPTIONS = {
@@ -496,7 +497,7 @@ const ProgramFeatures: React.FC = () => {
 
       toast({
         title: 'Feature Updated',
-        description: `Settings for ${featureType.replace(/_/g, ' ')} saved successfully`,
+        description: `Settings for ${formatFeatureType(featureType)} saved successfully`,
       });
     } catch (error: any) {
       console.error('❌ Save feature error:', error);


### PR DESCRIPTION
## Summary
- Add `formatFeatureType` helper for converting feature type constants into readable text
- Use helper in feature editor dialog title and program feature save toast

## Testing
- `npm run lint` *(fails: Unexpected any / no-case-declarations / etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3581c0b0832d98e6193b1f866481