### PR TITLE
Handle invalid JSON from Yelp API

### DIFF
--- a/backend/ads/tests/test_programs_invalid_json.py
+++ b/backend/ads/tests/test_programs_invalid_json.py
@@ -1,0 +1,28 @@
+import pytest
+import json
+import requests
+from rest_framework.test import APIClient
+from ads.services import YelpService
+
+pytestmark = pytest.mark.django_db
+
+
+def test_invalid_json_from_yelp(monkeypatch):
+    class DummyResponse:
+        status_code = 200
+        headers = {}
+        text = 'invalid'
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            raise json.JSONDecodeError("Expecting value", "", 0)
+
+    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: DummyResponse())
+    monkeypatch.setattr(YelpService, "_get_partner_auth", classmethod(lambda cls: ("user", "pass")))
+
+    client = APIClient()
+    response = client.get("/api/reseller/programs")
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Invalid JSON from Yelp API"

--- a/backend/ads/views.py
+++ b/backend/ads/views.py
@@ -197,7 +197,8 @@ class ProgramListView(APIView):
             return Response(data)
         except Exception as e:
             logger.error(f"Error getting programs list from Yelp API: {e}")
-            raise
+            status_code = getattr(getattr(e, 'response', None), 'status_code', status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": str(e)}, status=status_code)
 
 
 class ProgramInfoView(APIView):


### PR DESCRIPTION
## Summary
- return detailed error messages in program list view when Yelp API calls fail
- handle HTTP and JSON decoding errors in `YelpService.get_all_programs`
- add test for invalid JSON responses from Yelp

## Testing
- `YELP_API_KEY=a YELP_API_SECRET=b YELP_FUSION_TOKEN=c DATABASE_URL=sqlite:///mydb.sqlite3 DJANGO_SETTINGS_MODULE=backend.settings pytest backend/ads/tests/test_programs_invalid_json.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59c8c1d90832da5219cd5642ae955