### PR TITLE
feat: handle program fetch errors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -81,6 +82,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.6.0"
   }
 }

--- a/frontend/src/components/ApiErrorMessage.test.tsx
+++ b/frontend/src/components/ApiErrorMessage.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import ApiErrorMessage from './ApiErrorMessage';
+
+describe('ApiErrorMessage', () => {
+  it('renders detail message when provided by backend', () => {
+    const error = { status: 400, data: { detail: 'Bad request detail' } } as any;
+    const html = ReactDOMServer.renderToString(<ApiErrorMessage error={error} />);
+    expect(html).toContain('Bad request detail');
+  });
+
+  it('renders status and statusText when detail is missing', () => {
+    const error = { status: 500, data: {}, statusText: 'Internal Server Error' } as any;
+    const html = ReactDOMServer.renderToString(<ApiErrorMessage error={error} />);
+    expect(html).toContain('HTTP 500: Internal Server Error');
+  });
+});

--- a/frontend/src/components/ApiErrorMessage.tsx
+++ b/frontend/src/components/ApiErrorMessage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
+
+interface ApiErrorMessageProps {
+  error: FetchBaseQueryError & { statusText?: string };
+}
+
+const ApiErrorMessage: React.FC<ApiErrorMessageProps> = ({ error }) => {
+  let message: string;
+  const data: any = (error as any)?.data;
+  if (data && typeof data === 'object' && data.detail) {
+    message = String(data.detail);
+  } else {
+    const status = error.status;
+    const statusText = (error as any).statusText || (error as any).error || 'Unknown Error';
+    message = `HTTP ${status}: ${statusText}`;
+  }
+  return <>{message}</>;
+};
+
+export default ApiErrorMessage;

--- a/frontend/src/components/ProgramsList.tsx
+++ b/frontend/src/components/ProgramsList.tsx
@@ -10,8 +10,9 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { useNavigate } from 'react-router-dom';
 import { Loader2, Edit, Square, Play, Trash2, Settings, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
-import { toast } from '@/hooks/use-toast';
-import { formatErrorForToast } from '@/lib/utils';
+  import { toast } from '@/hooks/use-toast';
+  import { formatErrorForToast } from '@/lib/utils';
+  import ApiErrorMessage from './ApiErrorMessage';
 
 const ProgramsList: React.FC = () => {
   const [offset, setOffset] = useState(0);
@@ -89,7 +90,7 @@ const ProgramsList: React.FC = () => {
   };
   
   // Regular programs
-  const { data, isLoading, error, refetch } = useGetProgramsQuery({ 
+  const { data, isLoading, error, isError, refetch } = useGetProgramsQuery({
     offset: offset, 
     limit: limit,
     program_status: programStatus,
@@ -191,13 +192,13 @@ const ProgramsList: React.FC = () => {
     );
   }
 
-  if (error) {
+  if (isError && error && 'status' in error) {
     return (
       <Card className="w-full max-w-2xl mx-auto">
         <CardContent className="pt-6">
           <p className="text-red-500">Error loading programs</p>
           <p className="text-sm text-gray-600 mt-2">
-            {error && 'status' in error && `HTTP ${error.status}: ${error.data?.error?.message || 'Unknown error'}`}
+            <ApiErrorMessage error={error as any} />
           </p>
         </CardContent>
       </Card>

--- a/frontend/src/store/api/yelpApi.ts
+++ b/frontend/src/store/api/yelpApi.ts
@@ -1,6 +1,7 @@
 
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import type { RootState } from '../index';
+import type { BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import {
   Program,
   CreateProgramRequest,
@@ -58,7 +59,7 @@ export interface PortfolioPhotoUploadRequest {
   caption: string;
 }
 
-const baseQuery = fetchBaseQuery({
+const rawBaseQuery = fetchBaseQuery({
   baseUrl: '/api', // Proxy through backend
   prepareHeaders: (headers, { getState }) => {
     headers.set('Content-Type', 'application/json');
@@ -70,6 +71,19 @@ const baseQuery = fetchBaseQuery({
     return headers;
   },
 });
+
+const baseQuery: BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError & { statusText?: string }
+> = async (args, api, extraOptions) => {
+  const result = await rawBaseQuery(args, api, extraOptions);
+  if (result.error) {
+    const statusText = (result.meta as any)?.response?.statusText;
+    (result.error as any).statusText = statusText;
+  }
+  return result;
+};
 
 export const yelpApi = createApi({
   reducerPath: 'yelpApi',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,9 +20,12 @@ export default defineConfig(({ mode }) => ({
     mode === 'development' &&
     componentTagger(),
   ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
-}));
+    test: {
+      environment: 'jsdom'
+    },
+  }));


### PR DESCRIPTION
## Summary
- show backend detail or HTTP code when program list fails to load
- add ApiErrorMessage component and tests
- configure vite test environment

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a158eda0832db285a472f0cd48eb